### PR TITLE
Update to 1.16.236

### DIFF
--- a/Plugin/CMakeLists.txt
+++ b/Plugin/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.26)
 # info
 project(
   SFSEAsiLoader
-  VERSION 1.15.27
+  VERSION 1.16.23
   LANGUAGES CXX)
 
 # boiler

--- a/Plugin/src/main.cpp
+++ b/Plugin/src/main.cpp
@@ -35,7 +35,7 @@ DLLEXPORT constinit auto SFSEPlugin_Version = []() noexcept {
 	data.UsesAddressLibrary(true);
 	data.HasNoStructUse(true);
 	// data.IsLayoutDependent(true);
-	data.CompatibleVersions({ RUNTIME_VERSION_1_15_216, RUNTIME_VERSION_1_15_222 });
+	data.CompatibleVersions({ RUNTIME_VERSION_1_15_216, RUNTIME_VERSION_1_15_222, RUNTIME_VERSION_1_16_236 });
 
 	return data;
 }();

--- a/Plugin/vcpkg.json
+++ b/Plugin/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "sfseasiloader",
-  "version-string": "1.15.222",
+  "version-string": "1.16.236",
   "description": "updated asi loader for sfse",
   "homepage": "https://github.com/IanE-Official/rehash-sfse-asi-loader",
   "dependencies": [

--- a/README.html
+++ b/README.html
@@ -1126,7 +1126,7 @@ pwsh build-release.ps1
 
 <blockquote>
 <p>If you are building for a Starfield <strong><em>other than the latest</em></strong>, use <code>git clone https://github.com/IanE-Official/rehash-sfse-asi-loader.git --branch {version} sfse-asi-loader</code>
-where {version} is set to the newest version of starfield you are trying to build for (currently 1.15.222).</p>
+where {version} is set to the newest version of starfield you are trying to build for (currently 1.16.236).</p>
 </blockquote>
 <h3 id="deployment">📦 Deployment<a class="headerlink" href="#deployment" title="Permanent link"></a></h3>
 <p>Automated steps in Build-release.ps1 will automatically handle deployment.</p>

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ pwsh build-release.ps1
 ```
 
 > If you are building for a Starfield **_other than the latest_**, use `git clone https://github.com/IanE-Official/rehash-sfse-asi-loader.git --branch {version} sfse-asi-loader`
-> where {version} is set to the newest version of starfield you are trying to build for (currently 1.15.222).
+> where {version} is set to the newest version of starfield you are trying to build for (currently 1.16.236).
 
 ### 📦 Deployment
 


### PR DESCRIPTION
- Updated the version flags in CMakeLists.txt, main.cpp, and vcpkg.json
- Updated version named in Readme
- Bump extern/SFSE from `3f4bbe8` to `912b3cb`
- Switched back to brand-name magic smoke